### PR TITLE
group association results into sets

### DIFF
--- a/src/main/resources/avro/genotypephenotype.avdl
+++ b/src/main/resources/avro/genotypephenotype.avdl
@@ -39,6 +39,27 @@ import idl "metadata.avdl";
 import idl "sequenceAnnotations.avdl";
 
 
+/** 
+A PhenotypeAssociationSet is a collection of phenotype association results. 
+Such results are grouped by data source and possibly release version or analysis 
+type. 
+*/
+record PhenotypeAssociationSet {
+  /** The phenotype association set ID. */
+  string id;
+
+  /** The phenotype association set name. */
+  union { null, string } name = null;
+
+  /** The ID of the dataset this phenotype association set belongs to. */
+  string datasetId;
+
+  /**
+  Optional additional information for this phenotype association set.
+  */
+  map<array<string>> info = {};
+}
+
 /**
 The context in which a genotype gives rise to a phenotype.
 This is fairly open-ended; as a stub we have a simple ontology term.
@@ -131,6 +152,12 @@ such as resulting from alternative experiments and analysis.
 */
 record FeaturePhenotypeAssociation {
   string id;
+
+  /** 
+  The ID of the PhenotypeAssociationSet this FeaturePhenotypeAssociation
+  belongs to. 
+  */
+  string phenotypeAssociationId;
 
   /**
     The set of features of the organism that bears the phenotype.

--- a/src/main/resources/avro/genotypephenotypemethods.avdl
+++ b/src/main/resources/avro/genotypephenotypemethods.avdl
@@ -24,6 +24,55 @@ import idl "genotypephenotype.avdl";
 import idl "methods.avdl";
 import idl "common.avdl";
 
+/******************  /phenotypeassociationsets/search  *********************/
+/** This request maps to the body of `POST /phenotypeassociationsets/search` as JSON. */
+record SearchPhenotypeAssociationSetsRequest {
+  /**
+  The `Dataset` to search.
+  */
+  string datasetId;
+
+  /**
+  Specifies the maximum number of results to return in a single page.
+  If unspecified, a system default will be used.
+  */
+  union { null, int } pageSize = null;
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  To get the next page of results, set this parameter to the value of
+  `nextPageToken` from the previous response.
+  */
+  union { null, string } pageToken = null;
+}
+
+/** This is the response from `POST /phenotypeassociationsets/search` expressed as JSON. */
+record SearchPhenotypeAssociationSetsResponse {
+  
+  /** The list of matching phenotype association sets. */
+  array<org.ga4gh.models.PhenotypeAssociationSet> phenotypeAssociationSets = [];
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  Provide this value in a subsequent request to return the next page of
+  results. This field will be empty if there aren't any additional results.
+  */
+  union { null, string } nextPageToken = null;
+}
+
+/**
+Gets a list of `PhenotypeAssociationSet`s matching the search criteria.
+
+`POST /phenotypeassociationsets/search` must accept a JSON version of
+`SearchPhenotypeAssociationSetsRequest` as the post body and will return a JSON version
+of `SearchPhenotypeAssociationSetsResponse`.
+*/
+SearchPhenotypeAssociationSetsResponse searchPhenotypeAssociationSets(
+  /** This request maps to the body of `POST /phenotypeassociationsets/search` as JSON. */
+  SearchPhenotypeAssociationSetsRequest request) throws GAException;
+
+
+
 /******************  /genotypephenotype/search  *********************/
 
 
@@ -100,6 +149,11 @@ identifers (such as for gene or SNP ids), ontology term ids, or
 full feature/phenotype/evidence objects.
 */
 record SearchGenotypePhenotypeRequest {
+
+  /**
+  The `PhenotypeAssociationSet` to search.
+  */
+  string phenotypeAssociationSetId;
 
   union {null, string, ExternalIdentifierQuery, OntologyTermQuery,
          GenomicFeatureQuery} feature = null;


### PR DESCRIPTION
This is a shows how association results could be grouped within 2 levels of sets, following patterns used in the other schemas.

In this context an example of a dataset could be a project like the GWAS catalog or ClinVar and a PhenotypeAssociationSet could be the December 2015 release from such a project. PhenotypeAssociationSets could alternatively be the results of different analysis methods on the same raw data, in which case adding an Analysis record to PhenotypeAssociationSet may be useful.

This is an initial suggestion for discussion/refinement on today's call.
